### PR TITLE
Add initial ChurchCore CMS plugin

### DIFF
--- a/churchcore.php
+++ b/churchcore.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name:       ChurchCore CMS
+ * Plugin URI:        https://example.com/churchcore
+ * Description:       A centralized church management system integrating with Fluent CRM, Fluent Boards, Fluent Forms, and WooCommerce.
+ * Version:           0.1.0
+ * Author:            ChurchCore Contributors
+ * Author URI:        https://example.com
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       churchcore
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'CHURCHCORE_PLUGIN_VERSION', '0.1.0' );
+define( 'CHURCHCORE_PLUGIN_FILE', __FILE__ );
+define( 'CHURCHCORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'CHURCHCORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once CHURCHCORE_PLUGIN_DIR . 'includes/class-churchcore-plugin.php';
+
+function churchcore_run_plugin() {
+    $plugin = new ChurchCore_Plugin();
+    $plugin->run();
+}
+
+register_activation_hook( __FILE__, array( 'ChurchCore_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'ChurchCore_Plugin', 'deactivate' ) );
+
+churchcore_run_plugin();

--- a/includes/admin/churchcore-admin.css
+++ b/includes/admin/churchcore-admin.css
@@ -1,0 +1,60 @@
+.churchcore-wrap {
+    max-width: 1100px;
+}
+
+.churchcore-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.churchcore-card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 5px 15px rgba(30, 30, 30, 0.05);
+}
+
+.churchcore-card h2 {
+    margin-top: 0;
+}
+
+.churchcore-metrics {
+    display: flex;
+    gap: 24px;
+    margin: 20px 0;
+}
+
+.churchcore-metric {
+    flex: 1;
+    background: #f6f7f7;
+    border-radius: 6px;
+    padding: 12px 16px;
+    text-align: center;
+}
+
+.churchcore-form-group {
+    margin-bottom: 16px;
+}
+
+.churchcore-form-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.churchcore-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.churchcore-table th,
+.churchcore-table td {
+    border-bottom: 1px solid #e2e4e7;
+    padding: 10px;
+    text-align: left;
+}
+
+.churchcore-table th {
+    background-color: #f6f7f7;
+}

--- a/includes/admin/views/dashboard.php
+++ b/includes/admin/views/dashboard.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Dashboard overview.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$fam_count    = wp_count_posts( 'cc_family' );
+$people_count = wp_count_posts( 'cc_person' );
+
+$families_total = isset( $fam_count->publish ) ? (int) $fam_count->publish : 0;
+$people_total   = isset( $people_count->publish ) ? (int) $people_count->publish : 0;
+
+$latest_families = get_posts(
+    array(
+        'post_type'      => 'cc_family',
+        'posts_per_page' => 5,
+        'post_status'    => 'any',
+    )
+);
+
+$latest_people = get_posts(
+    array(
+        'post_type'      => 'cc_person',
+        'posts_per_page' => 5,
+        'post_status'    => 'any',
+    )
+);
+?>
+<div class="wrap churchcore-wrap">
+    <h1><?php esc_html_e( 'ChurchCore Overview', 'churchcore' ); ?></h1>
+    <?php settings_errors( 'churchcore' ); ?>
+    <div class="churchcore-metrics">
+        <div class="churchcore-metric">
+            <strong><?php esc_html_e( 'Families', 'churchcore' ); ?></strong>
+            <div><?php echo esc_html( $families_total ); ?></div>
+        </div>
+        <div class="churchcore-metric">
+            <strong><?php esc_html_e( 'People', 'churchcore' ); ?></strong>
+            <div><?php echo esc_html( $people_total ); ?></div>
+        </div>
+        <div class="churchcore-metric">
+            <strong><?php esc_html_e( 'Connected Apps', 'churchcore' ); ?></strong>
+            <div><?php echo esc_html( count( array_filter( ( new ChurchCore_Integrations() )->get_status() ) ) ); ?></div>
+        </div>
+    </div>
+    <div class="churchcore-grid">
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Recent Families', 'churchcore' ); ?></h2>
+            <table class="churchcore-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Family', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Status', 'churchcore' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $latest_families as $family ) : ?>
+                    <?php
+                    $status_obj   = get_post_status_object( $family->post_status );
+                    $status_label = $status_obj ? $status_obj->label : $family->post_status;
+                    ?>
+                    <tr>
+                        <td><a href="<?php echo esc_url( get_edit_post_link( $family->ID ) ); ?>"><?php echo esc_html( get_the_title( $family ) ); ?></a></td>
+                        <td><?php echo esc_html( $status_label ); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Recent People', 'churchcore' ); ?></h2>
+            <table class="churchcore-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Name', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Email', 'churchcore' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $latest_people as $person ) : ?>
+                    <tr>
+                        <td><a href="<?php echo esc_url( get_edit_post_link( $person->ID ) ); ?>"><?php echo esc_html( get_the_title( $person ) ); ?></a></td>
+                        <td><?php echo esc_html( get_post_meta( $person->ID, '_churchcore_email', true ) ); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/includes/admin/views/families.php
+++ b/includes/admin/views/families.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Families management screen.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$families = get_posts(
+    array(
+        'post_type'      => 'cc_family',
+        'posts_per_page' => 20,
+        'post_status'    => 'any',
+    )
+);
+?>
+<div class="wrap churchcore-wrap">
+    <h1><?php esc_html_e( 'Families', 'churchcore' ); ?></h1>
+    <?php settings_errors( 'churchcore' ); ?>
+    <div class="churchcore-grid">
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Add Family', 'churchcore' ); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field( 'churchcore_action' ); ?>
+                <input type="hidden" name="churchcore_action" value="add_family" />
+                <div class="churchcore-form-group">
+                    <label for="family_name"><?php esc_html_e( 'Family Name', 'churchcore' ); ?></label>
+                    <input type="text" id="family_name" name="family_name" class="regular-text" required />
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="family_status"><?php esc_html_e( 'Status', 'churchcore' ); ?></label>
+                    <select id="family_status" name="family_status">
+                        <option value="publish"><?php esc_html_e( 'Active', 'churchcore' ); ?></option>
+                        <option value="draft"><?php esc_html_e( 'Prospect', 'churchcore' ); ?></option>
+                        <option value="follow-up"><?php esc_html_e( 'Follow Up Needed', 'churchcore' ); ?></option>
+                    </select>
+                </div>
+                <?php submit_button( __( 'Add Family', 'churchcore' ) ); ?>
+            </form>
+        </div>
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Family Directory', 'churchcore' ); ?></h2>
+            <table class="churchcore-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Family', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Members', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Status', 'churchcore' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $families as $family ) :
+                    $member_count = count( get_posts(
+                        array(
+                            'post_type'      => 'cc_person',
+                            'posts_per_page' => -1,
+                            'post_status'    => 'any',
+                            'meta_query'     => array(
+                                array(
+                                    'key'   => '_churchcore_family_id',
+                                    'value' => $family->ID,
+                                ),
+                            ),
+                        )
+                    ) );
+                    $status_obj   = get_post_status_object( $family->post_status );
+                    $status_label = $status_obj ? $status_obj->label : $family->post_status;
+                    ?>
+                    <tr>
+                        <td><a href="<?php echo esc_url( get_edit_post_link( $family->ID ) ); ?>"><?php echo esc_html( get_the_title( $family ) ); ?></a></td>
+                        <td><?php echo esc_html( $member_count ); ?></td>
+                        <td><?php echo esc_html( $status_label ); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/includes/admin/views/integrations.php
+++ b/includes/admin/views/integrations.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Integrations overview screen.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$integration = new ChurchCore_Integrations();
+$status      = $integration->get_status();
+?>
+<div class="wrap churchcore-wrap">
+    <h1><?php esc_html_e( 'Integrations', 'churchcore' ); ?></h1>
+    <p><?php esc_html_e( 'Connect your existing Fluent apps and WooCommerce store to surface giving, communication, and volunteer data in one place.', 'churchcore' ); ?></p>
+    <div class="churchcore-grid">
+        <?php foreach ( $status as $slug => $active ) : ?>
+            <div class="churchcore-card">
+                <h2><?php echo esc_html( ucfirst( $slug ) ); ?></h2>
+                <p>
+                    <?php
+                    if ( $active ) {
+                        esc_html_e( 'Active and syncing.', 'churchcore' );
+                    } else {
+                        esc_html_e( 'Not detected. Activate the plugin to enable syncing.', 'churchcore' );
+                    }
+                    ?>
+                </p>
+                <?php if ( ! $active ) : ?>
+                    <p><a class="button button-primary" href="<?php echo esc_url( admin_url( 'plugins.php' ) ); ?>"><?php esc_html_e( 'Manage Plugins', 'churchcore' ); ?></a></p>
+                <?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <div class="churchcore-card">
+        <h2><?php esc_html_e( 'Automation Recipes', 'churchcore' ); ?></h2>
+        <p><?php esc_html_e( 'Use FluentCRM and Fluent Forms to build follow-up workflows for new visitors, volunteers, and donors. ChurchCore exposes key merge tags to personalize automations.', 'churchcore' ); ?></p>
+        <ul>
+            <li><?php esc_html_e( 'Send a welcome email when a new family is added.', 'churchcore' ); ?></li>
+            <li><?php esc_html_e( 'Create a Fluent Board card when a pastoral care note is logged.', 'churchcore' ); ?></li>
+            <li><?php esc_html_e( 'Tag WooCommerce donors when they complete a purchase.', 'churchcore' ); ?></li>
+        </ul>
+    </div>
+</div>

--- a/includes/admin/views/notes.php
+++ b/includes/admin/views/notes.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Notes management screen.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+global $wpdb;
+
+$table  = $wpdb->prefix . 'churchcore_notes';
+$notes  = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY created_at DESC LIMIT 50" );
+$people = get_posts(
+    array(
+        'post_type'      => 'cc_person',
+        'posts_per_page' => -1,
+        'post_status'    => 'any',
+        'orderby'        => 'title',
+        'order'          => 'ASC',
+    )
+);
+$families = get_posts(
+    array(
+        'post_type'      => 'cc_family',
+        'posts_per_page' => -1,
+        'post_status'    => 'any',
+        'orderby'        => 'title',
+        'order'          => 'ASC',
+    )
+);
+?>
+<div class="wrap churchcore-wrap">
+    <h1><?php esc_html_e( 'Notes', 'churchcore' ); ?></h1>
+    <?php settings_errors( 'churchcore' ); ?>
+    <div class="churchcore-grid">
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Add Note', 'churchcore' ); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field( 'churchcore_action' ); ?>
+                <input type="hidden" name="churchcore_action" value="add_note" />
+                <div class="churchcore-form-group">
+                    <label for="note_related_type"><?php esc_html_e( 'Related To', 'churchcore' ); ?></label>
+                    <select id="note_related_type" name="note_related_type" required>
+                        <option value="person"><?php esc_html_e( 'Person', 'churchcore' ); ?></option>
+                        <option value="family"><?php esc_html_e( 'Family', 'churchcore' ); ?></option>
+                    </select>
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="note_related_id"><?php esc_html_e( 'Record', 'churchcore' ); ?></label>
+                    <select id="note_related_id" name="note_related_id" required>
+                        <optgroup label="<?php esc_attr_e( 'People', 'churchcore' ); ?>">
+                            <?php foreach ( $people as $person ) : ?>
+                                <option value="<?php echo esc_attr( $person->ID ); ?>" data-type="person"><?php echo esc_html( get_the_title( $person ) ); ?></option>
+                            <?php endforeach; ?>
+                        </optgroup>
+                        <optgroup label="<?php esc_attr_e( 'Families', 'churchcore' ); ?>">
+                            <?php foreach ( $families as $family ) : ?>
+                                <option value="<?php echo esc_attr( $family->ID ); ?>" data-type="family"><?php echo esc_html( get_the_title( $family ) ); ?></option>
+                            <?php endforeach; ?>
+                        </optgroup>
+                    </select>
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="note_content"><?php esc_html_e( 'Note', 'churchcore' ); ?></label>
+                    <textarea id="note_content" name="note_content" rows="4" class="large-text" required></textarea>
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="note_visibility"><?php esc_html_e( 'Visibility', 'churchcore' ); ?></label>
+                    <select id="note_visibility" name="note_visibility">
+                        <option value="private"><?php esc_html_e( 'Private', 'churchcore' ); ?></option>
+                        <option value="team"><?php esc_html_e( 'Team', 'churchcore' ); ?></option>
+                    </select>
+                </div>
+                <?php submit_button( __( 'Add Note', 'churchcore' ) ); ?>
+            </form>
+        </div>
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Recent Notes', 'churchcore' ); ?></h2>
+            <table class="churchcore-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Date', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Related', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Author', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Visibility', 'churchcore' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $notes as $note ) :
+                    $link = 'person' === $note->related_type ? get_edit_post_link( $note->related_id ) : get_edit_post_link( $note->related_id );
+                    ?>
+                    <tr>
+                        <td><?php echo esc_html( mysql2date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $note->created_at ) ); ?></td>
+                        <td><a href="<?php echo esc_url( $link ); ?>"><?php echo esc_html( get_the_title( $note->related_id ) ); ?></a></td>
+                        <td><?php echo esc_html( get_the_author_meta( 'display_name', $note->author_id ) ); ?></td>
+                        <td><?php echo esc_html( ucfirst( $note->visibility ) ); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/includes/admin/views/people.php
+++ b/includes/admin/views/people.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * People management screen.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$people   = get_posts(
+    array(
+        'post_type'      => 'cc_person',
+        'posts_per_page' => 20,
+        'post_status'    => 'any',
+    )
+);
+$families = get_posts(
+    array(
+        'post_type'      => 'cc_family',
+        'posts_per_page' => -1,
+        'post_status'    => 'any',
+        'orderby'        => 'title',
+        'order'          => 'ASC',
+    )
+);
+$roles = get_terms(
+    array(
+        'taxonomy'   => 'cc_role',
+        'hide_empty' => false,
+    )
+);
+?>
+<div class="wrap churchcore-wrap">
+    <h1><?php esc_html_e( 'People', 'churchcore' ); ?></h1>
+    <?php settings_errors( 'churchcore' ); ?>
+    <div class="churchcore-grid">
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'Add Person', 'churchcore' ); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field( 'churchcore_action' ); ?>
+                <input type="hidden" name="churchcore_action" value="add_person" />
+                <div class="churchcore-form-group">
+                    <label for="person_name"><?php esc_html_e( 'Name', 'churchcore' ); ?></label>
+                    <input type="text" id="person_name" name="person_name" class="regular-text" required />
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="person_email"><?php esc_html_e( 'Email', 'churchcore' ); ?></label>
+                    <input type="email" id="person_email" name="person_email" class="regular-text" />
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="person_phone"><?php esc_html_e( 'Phone', 'churchcore' ); ?></label>
+                    <input type="text" id="person_phone" name="person_phone" class="regular-text" />
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="person_family"><?php esc_html_e( 'Family', 'churchcore' ); ?></label>
+                    <select id="person_family" name="person_family">
+                        <option value="0"><?php esc_html_e( 'Unassigned', 'churchcore' ); ?></option>
+                        <?php foreach ( $families as $family ) : ?>
+                            <option value="<?php echo esc_attr( $family->ID ); ?>"><?php echo esc_html( get_the_title( $family ) ); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="churchcore-form-group">
+                    <label for="person_role"><?php esc_html_e( 'Role', 'churchcore' ); ?></label>
+                    <input type="text" id="person_role" name="person_role" class="regular-text" list="churchcore_roles" />
+                    <datalist id="churchcore_roles">
+                        <?php foreach ( $roles as $role ) : ?>
+                            <option value="<?php echo esc_attr( $role->name ); ?>"></option>
+                        <?php endforeach; ?>
+                    </datalist>
+                </div>
+                <?php submit_button( __( 'Add Person', 'churchcore' ) ); ?>
+            </form>
+        </div>
+        <div class="churchcore-card">
+            <h2><?php esc_html_e( 'People Directory', 'churchcore' ); ?></h2>
+            <table class="churchcore-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Name', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Family', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Email', 'churchcore' ); ?></th>
+                        <th><?php esc_html_e( 'Role', 'churchcore' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $people as $person ) :
+                    $family_id = get_post_meta( $person->ID, '_churchcore_family_id', true );
+                    $family    = $family_id ? get_post( $family_id ) : null;
+                    $terms     = wp_get_post_terms( $person->ID, 'cc_role', array( 'fields' => 'names' ) );
+                    ?>
+                    <tr>
+                        <td><a href="<?php echo esc_url( get_edit_post_link( $person->ID ) ); ?>"><?php echo esc_html( get_the_title( $person ) ); ?></a></td>
+                        <td><?php echo esc_html( $family ? get_the_title( $family ) : __( 'Unassigned', 'churchcore' ) ); ?></td>
+                        <td><?php echo esc_html( get_post_meta( $person->ID, '_churchcore_email', true ) ); ?></td>
+                        <td><?php echo esc_html( implode( ', ', $terms ) ); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/includes/class-churchcore-admin-menu.php
+++ b/includes/class-churchcore-admin-menu.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Admin menu and UI rendering.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handles admin screens for ChurchCore.
+ */
+class ChurchCore_Admin_Menu {
+    /**
+     * Registers admin menus.
+     */
+    public function register_menus() {
+        add_menu_page(
+            __( 'ChurchCore', 'churchcore' ),
+            __( 'ChurchCore', 'churchcore' ),
+            'manage_churchcore',
+            'churchcore',
+            array( $this, 'render_dashboard' ),
+            'dashicons-church',
+            58
+        );
+
+        add_submenu_page(
+            'churchcore',
+            __( 'Families', 'churchcore' ),
+            __( 'Families', 'churchcore' ),
+            'manage_churchcore',
+            'churchcore-families',
+            array( $this, 'render_families' )
+        );
+
+        add_submenu_page(
+            'churchcore',
+            __( 'People', 'churchcore' ),
+            __( 'People', 'churchcore' ),
+            'manage_churchcore',
+            'churchcore-people',
+            array( $this, 'render_people' )
+        );
+
+        add_submenu_page(
+            'churchcore',
+            __( 'Notes', 'churchcore' ),
+            __( 'Notes', 'churchcore' ),
+            'manage_churchcore',
+            'churchcore-notes',
+            array( $this, 'render_notes' )
+        );
+
+        add_submenu_page(
+            'churchcore',
+            __( 'Integrations', 'churchcore' ),
+            __( 'Integrations', 'churchcore' ),
+            'manage_churchcore',
+            'churchcore-integrations',
+            array( $this, 'render_integrations' )
+        );
+    }
+
+    /**
+     * Load admin assets.
+     */
+    public function enqueue_assets( $hook_suffix ) {
+        if ( false === strpos( $hook_suffix, 'churchcore' ) ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'churchcore-admin',
+            CHURCHCORE_PLUGIN_URL . 'includes/admin/churchcore-admin.css',
+            array(),
+            CHURCHCORE_PLUGIN_VERSION
+        );
+    }
+
+    /**
+     * Handles admin POST actions.
+     */
+    public function handle_actions() {
+        if ( empty( $_POST['churchcore_action'] ) ) {
+            return;
+        }
+
+        if ( ! current_user_can( 'manage_churchcore' ) ) {
+            wp_die( esc_html__( 'You do not have permission to modify ChurchCore records.', 'churchcore' ) );
+        }
+
+        if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'churchcore_action' ) ) {
+            wp_die( esc_html__( 'Security check failed.', 'churchcore' ) );
+        }
+
+        $action  = sanitize_key( wp_unslash( $_POST['churchcore_action'] ) );
+        $handled = false;
+
+        switch ( $action ) {
+            case 'add_family':
+                $this->create_family();
+                $handled = true;
+                break;
+            case 'add_person':
+                $this->create_person();
+                $handled = true;
+                break;
+            case 'add_note':
+                $this->create_note();
+                $handled = true;
+                break;
+        }
+
+        if ( $handled ) {
+            $redirect = wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=churchcore' );
+            wp_safe_redirect( $redirect );
+            exit;
+        }
+    }
+
+    /**
+     * Dashboard screen.
+     */
+    public function render_dashboard() {
+        include CHURCHCORE_PLUGIN_DIR . 'includes/admin/views/dashboard.php';
+    }
+
+    /**
+     * Families screen.
+     */
+    public function render_families() {
+        include CHURCHCORE_PLUGIN_DIR . 'includes/admin/views/families.php';
+    }
+
+    /**
+     * People screen.
+     */
+    public function render_people() {
+        include CHURCHCORE_PLUGIN_DIR . 'includes/admin/views/people.php';
+    }
+
+    /**
+     * Notes screen.
+     */
+    public function render_notes() {
+        include CHURCHCORE_PLUGIN_DIR . 'includes/admin/views/notes.php';
+    }
+
+    /**
+     * Integrations screen.
+     */
+    public function render_integrations() {
+        include CHURCHCORE_PLUGIN_DIR . 'includes/admin/views/integrations.php';
+    }
+
+    /**
+     * Adds a family record.
+     */
+    protected function create_family() {
+        $family_name = isset( $_POST['family_name'] ) ? sanitize_text_field( wp_unslash( $_POST['family_name'] ) ) : '';
+        $status      = isset( $_POST['family_status'] ) ? sanitize_text_field( wp_unslash( $_POST['family_status'] ) ) : 'active';
+
+        if ( empty( $family_name ) ) {
+            add_settings_error( 'churchcore', 'family_name_required', __( 'Family name is required.', 'churchcore' ) );
+            return;
+        }
+
+        $post_id = wp_insert_post(
+            array(
+                'post_type'   => 'cc_family',
+                'post_title'  => $family_name,
+                'post_status' => $status,
+            ),
+            true
+        );
+
+        if ( is_wp_error( $post_id ) ) {
+            add_settings_error( 'churchcore', 'family_create_failed', $post_id->get_error_message() );
+        } else {
+            add_settings_error( 'churchcore', 'family_create_success', __( 'Family created successfully.', 'churchcore' ), 'updated' );
+        }
+    }
+
+    /**
+     * Adds a person record.
+     */
+    protected function create_person() {
+        $display_name = isset( $_POST['person_name'] ) ? sanitize_text_field( wp_unslash( $_POST['person_name'] ) ) : '';
+        $email        = isset( $_POST['person_email'] ) ? sanitize_email( wp_unslash( $_POST['person_email'] ) ) : '';
+        $phone        = isset( $_POST['person_phone'] ) ? sanitize_text_field( wp_unslash( $_POST['person_phone'] ) ) : '';
+        $role         = isset( $_POST['person_role'] ) ? sanitize_text_field( wp_unslash( $_POST['person_role'] ) ) : '';
+        $family_id    = isset( $_POST['person_family'] ) ? absint( $_POST['person_family'] ) : 0;
+
+        if ( empty( $display_name ) ) {
+            add_settings_error( 'churchcore', 'person_name_required', __( 'Person name is required.', 'churchcore' ) );
+            return;
+        }
+
+        $post_id = wp_insert_post(
+            array(
+                'post_type'   => 'cc_person',
+                'post_title'  => $display_name,
+                'post_status' => 'publish',
+            ),
+            true
+        );
+
+        if ( is_wp_error( $post_id ) ) {
+            add_settings_error( 'churchcore', 'person_create_failed', $post_id->get_error_message() );
+            return;
+        }
+
+        update_post_meta( $post_id, '_churchcore_email', $email );
+        update_post_meta( $post_id, '_churchcore_phone', $phone );
+        update_post_meta( $post_id, '_churchcore_family_id', $family_id );
+
+        if ( ! empty( $role ) ) {
+            wp_set_post_terms( $post_id, array( $role ), 'cc_role', false );
+        }
+
+        add_settings_error( 'churchcore', 'person_create_success', __( 'Person created successfully.', 'churchcore' ), 'updated' );
+    }
+
+    /**
+     * Adds a note record.
+     */
+    protected function create_note() {
+        global $wpdb;
+
+        $related_type = isset( $_POST['note_related_type'] ) ? sanitize_text_field( wp_unslash( $_POST['note_related_type'] ) ) : '';
+        $related_id   = isset( $_POST['note_related_id'] ) ? absint( $_POST['note_related_id'] ) : 0;
+        $content      = isset( $_POST['note_content'] ) ? wp_kses_post( wp_unslash( $_POST['note_content'] ) ) : '';
+        $visibility   = isset( $_POST['note_visibility'] ) ? sanitize_text_field( wp_unslash( $_POST['note_visibility'] ) ) : 'private';
+
+        $allowed_types = array(
+            'person' => 'cc_person',
+            'family' => 'cc_family',
+        );
+
+        if ( empty( $related_type ) || empty( $related_id ) || empty( $content ) ) {
+            add_settings_error( 'churchcore', 'note_required', __( 'All note fields are required.', 'churchcore' ) );
+            return;
+        }
+
+        if ( ! isset( $allowed_types[ $related_type ] ) ) {
+            add_settings_error( 'churchcore', 'note_type_invalid', __( 'Invalid note relationship selected.', 'churchcore' ) );
+            return;
+        }
+
+        $related_post_type = get_post_type( $related_id );
+        if ( $allowed_types[ $related_type ] !== $related_post_type ) {
+            add_settings_error( 'churchcore', 'note_post_type_mismatch', __( 'The selected record does not match the relationship type.', 'churchcore' ) );
+            return;
+        }
+
+        $table = $wpdb->prefix . 'churchcore_notes';
+
+        $inserted = $wpdb->insert(
+            $table,
+            array(
+                'related_type' => $related_type,
+                'related_id'   => $related_id,
+                'author_id'    => get_current_user_id(),
+                'content'      => $content,
+                'visibility'   => $visibility,
+                'created_at'   => current_time( 'mysql', 1 ),
+            ),
+            array( '%s', '%d', '%d', '%s', '%s', '%s' )
+        );
+
+        if ( false === $inserted ) {
+            add_settings_error( 'churchcore', 'note_create_failed', __( 'Failed to create note.', 'churchcore' ) );
+        } else {
+            add_settings_error( 'churchcore', 'note_create_success', __( 'Note created successfully.', 'churchcore' ), 'updated' );
+        }
+    }
+}

--- a/includes/class-churchcore-custom-post-types.php
+++ b/includes/class-churchcore-custom-post-types.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Registers custom post types and taxonomies.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Custom post type registrar.
+ */
+class ChurchCore_Custom_Post_Types {
+    /**
+     * Register post types and taxonomies.
+     */
+    public function register() {
+        $this->register_family_post_type();
+        $this->register_person_post_type();
+        $this->register_relationship_taxonomy();
+    }
+
+    /**
+     * Families.
+     */
+    protected function register_family_post_type() {
+        $labels = array(
+            'name'               => __( 'Families', 'churchcore' ),
+            'singular_name'      => __( 'Family', 'churchcore' ),
+            'add_new_item'       => __( 'Add New Family', 'churchcore' ),
+            'edit_item'          => __( 'Edit Family', 'churchcore' ),
+            'new_item'           => __( 'New Family', 'churchcore' ),
+            'view_item'          => __( 'View Family', 'churchcore' ),
+            'search_items'       => __( 'Search Families', 'churchcore' ),
+            'not_found'          => __( 'No families found.', 'churchcore' ),
+            'not_found_in_trash' => __( 'No families found in Trash.', 'churchcore' ),
+        );
+
+        $args = array(
+            'label'               => __( 'Families', 'churchcore' ),
+            'labels'              => $labels,
+            'public'              => false,
+            'show_ui'             => true,
+            'show_in_menu'        => false,
+            'supports'            => array( 'title', 'editor', 'author' ),
+            'capability_type'     => 'post',
+            'map_meta_cap'        => true,
+            'has_archive'         => false,
+            'show_in_rest'        => true,
+            'menu_icon'           => 'dashicons-groups',
+        );
+
+        register_post_type( 'cc_family', $args );
+    }
+
+    /**
+     * People.
+     */
+    protected function register_person_post_type() {
+        $labels = array(
+            'name'               => __( 'People', 'churchcore' ),
+            'singular_name'      => __( 'Person', 'churchcore' ),
+            'add_new_item'       => __( 'Add New Person', 'churchcore' ),
+            'edit_item'          => __( 'Edit Person', 'churchcore' ),
+            'new_item'           => __( 'New Person', 'churchcore' ),
+            'view_item'          => __( 'View Person', 'churchcore' ),
+            'search_items'       => __( 'Search People', 'churchcore' ),
+            'not_found'          => __( 'No people found.', 'churchcore' ),
+            'not_found_in_trash' => __( 'No people found in Trash.', 'churchcore' ),
+        );
+
+        $args = array(
+            'label'               => __( 'People', 'churchcore' ),
+            'labels'              => $labels,
+            'public'              => false,
+            'show_ui'             => true,
+            'show_in_menu'        => false,
+            'supports'            => array( 'title', 'editor', 'author', 'custom-fields' ),
+            'capability_type'     => 'post',
+            'map_meta_cap'        => true,
+            'has_archive'         => false,
+            'show_in_rest'        => true,
+            'menu_icon'           => 'dashicons-id',
+        );
+
+        register_post_type( 'cc_person', $args );
+    }
+
+    /**
+     * Household and ministry relationships.
+     */
+    protected function register_relationship_taxonomy() {
+        $labels = array(
+            'name'              => __( 'Ministry Roles', 'churchcore' ),
+            'singular_name'     => __( 'Ministry Role', 'churchcore' ),
+            'search_items'      => __( 'Search Roles', 'churchcore' ),
+            'all_items'         => __( 'All Roles', 'churchcore' ),
+            'edit_item'         => __( 'Edit Role', 'churchcore' ),
+            'update_item'       => __( 'Update Role', 'churchcore' ),
+            'add_new_item'      => __( 'Add New Role', 'churchcore' ),
+            'new_item_name'     => __( 'New Role Name', 'churchcore' ),
+            'menu_name'         => __( 'Roles', 'churchcore' ),
+        );
+
+        $args = array(
+            'hierarchical'      => false,
+            'labels'            => $labels,
+            'show_ui'           => true,
+            'show_in_rest'      => true,
+            'show_admin_column' => true,
+            'rewrite'           => false,
+        );
+
+        register_taxonomy( 'cc_role', array( 'cc_person' ), $args );
+    }
+}

--- a/includes/class-churchcore-integrations.php
+++ b/includes/class-churchcore-integrations.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Integrations with other Fluent and WooCommerce products.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Detects and surfaces integration points.
+ */
+class ChurchCore_Integrations {
+    /**
+     * Cached integration statuses.
+     *
+     * @var array
+     */
+    protected $status_cache;
+
+    /**
+     * Returns integration availability.
+     *
+     * @return array
+     */
+    public function get_status() {
+        if ( null !== $this->status_cache ) {
+            return $this->status_cache;
+        }
+
+        include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        $this->status_cache = array(
+            'fluentcrm'    => is_plugin_active( 'fluent-crm/fluent-crm.php' ),
+            'fluentforms'  => is_plugin_active( 'fluentform/fluentform.php' ),
+            'fluentboards' => is_plugin_active( 'fluent-boards/fluent-boards.php' ),
+            'woocommerce'  => is_plugin_active( 'woocommerce/woocommerce.php' ),
+        );
+
+        return $this->status_cache;
+    }
+
+    /**
+     * Outputs admin notices when integrations are missing.
+     */
+    public function render_notices() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $status = $this->get_status();
+
+        foreach ( $status as $integration => $active ) {
+            if ( $active ) {
+                continue;
+            }
+
+            $plugin_name = $this->get_integration_label( $integration );
+            printf(
+                '<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
+                esc_html( sprintf( __( '%s is not active. Activate it to unlock deeper ChurchCore sync.', 'churchcore' ), $plugin_name ) )
+            );
+        }
+    }
+
+    /**
+     * Returns a human-readable label.
+     *
+     * @param string $integration Integration slug.
+     * @return string
+     */
+    protected function get_integration_label( $integration ) {
+        $labels = array(
+            'fluentcrm'    => __( 'FluentCRM', 'churchcore' ),
+            'fluentforms'  => __( 'Fluent Forms', 'churchcore' ),
+            'fluentboards' => __( 'Fluent Boards', 'churchcore' ),
+            'woocommerce'  => __( 'WooCommerce', 'churchcore' ),
+        );
+
+        return isset( $labels[ $integration ] ) ? $labels[ $integration ] : $integration;
+    }
+}

--- a/includes/class-churchcore-plugin.php
+++ b/includes/class-churchcore-plugin.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Main plugin loader.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once CHURCHCORE_PLUGIN_DIR . 'includes/class-churchcore-custom-post-types.php';
+require_once CHURCHCORE_PLUGIN_DIR . 'includes/class-churchcore-admin-menu.php';
+require_once CHURCHCORE_PLUGIN_DIR . 'includes/class-churchcore-integrations.php';
+require_once CHURCHCORE_PLUGIN_DIR . 'includes/class-churchcore-shortcodes.php';
+
+/**
+ * Core plugin class.
+ */
+class ChurchCore_Plugin {
+    /**
+     * Custom post type registrar.
+     *
+     * @var ChurchCore_Custom_Post_Types
+     */
+    protected $cpt;
+
+    /**
+     * Admin menu handler.
+     *
+     * @var ChurchCore_Admin_Menu
+     */
+    protected $admin_menu;
+
+    /**
+     * Integration handler.
+     *
+     * @var ChurchCore_Integrations
+     */
+    protected $integrations;
+
+    /**
+     * Shortcode handler.
+     *
+     * @var ChurchCore_Shortcodes
+     */
+    protected $shortcodes;
+
+    /**
+     * Bootstraps dependencies.
+     */
+    public function __construct() {
+        $this->cpt           = new ChurchCore_Custom_Post_Types();
+        $this->admin_menu    = new ChurchCore_Admin_Menu();
+        $this->integrations  = new ChurchCore_Integrations();
+        $this->shortcodes    = new ChurchCore_Shortcodes();
+    }
+
+    /**
+     * Registers hooks with WordPress.
+     */
+    public function run() {
+        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        add_action( 'init', array( $this->cpt, 'register' ) );
+        add_action( 'init', array( $this, 'register_roles' ) );
+        add_action( 'init', array( $this, 'register_statuses' ) );
+        add_action( 'admin_menu', array( $this->admin_menu, 'register_menus' ) );
+        add_action( 'admin_init', array( $this->admin_menu, 'handle_actions' ) );
+        add_action( 'admin_enqueue_scripts', array( $this->admin_menu, 'enqueue_assets' ) );
+        add_action( 'admin_notices', array( $this->integrations, 'render_notices' ) );
+        add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+        $this->shortcodes->register();
+    }
+
+    /**
+     * Loads the plugin text domain for translation.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'churchcore', false, dirname( plugin_basename( CHURCHCORE_PLUGIN_FILE ) ) . '/languages/' );
+    }
+
+    /**
+     * Creates data tables on activation.
+     */
+    public static function activate() {
+        global $wpdb;
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset_collate = $wpdb->get_charset_collate();
+
+        $families_table = $wpdb->prefix . 'churchcore_families';
+        $people_table   = $wpdb->prefix . 'churchcore_people';
+        $notes_table    = $wpdb->prefix . 'churchcore_notes';
+
+        $sql_families = "CREATE TABLE {$families_table} (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            family_name VARCHAR(255) NOT NULL,
+            status VARCHAR(50) NOT NULL DEFAULT 'active',
+            metadata LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id)
+        ) {$charset_collate};";
+
+        $sql_people = "CREATE TABLE {$people_table} (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            family_id BIGINT(20) UNSIGNED NULL,
+            display_name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) NULL,
+            phone VARCHAR(50) NULL,
+            role VARCHAR(100) NULL,
+            metadata LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY family_id (family_id)
+        ) {$charset_collate};";
+
+        $sql_notes = "CREATE TABLE {$notes_table} (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            related_type VARCHAR(50) NOT NULL,
+            related_id BIGINT(20) UNSIGNED NOT NULL,
+            author_id BIGINT(20) UNSIGNED NOT NULL,
+            content LONGTEXT NOT NULL,
+            visibility VARCHAR(20) NOT NULL DEFAULT 'private',
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY related (related_type, related_id)
+        ) {$charset_collate};";
+
+        dbDelta( $sql_families );
+        dbDelta( $sql_people );
+        dbDelta( $sql_notes );
+
+        $instance = new self();
+        $instance->register_roles();
+
+        flush_rewrite_rules();
+    }
+
+    /**
+     * Removes rewrites on deactivation.
+     */
+    public static function deactivate() {
+        flush_rewrite_rules();
+    }
+
+    /**
+     * Registers custom roles used by the CMS.
+     */
+    public function register_roles() {
+        if ( ! get_role( 'churchcore_manager' ) ) {
+            add_role(
+                'churchcore_manager',
+                __( 'Church Manager', 'churchcore' ),
+                array(
+                    'read'              => true,
+                    'edit_posts'        => true,
+                    'publish_posts'     => true,
+                    'list_users'        => true,
+                    'create_users'      => true,
+                    'delete_users'      => false,
+                    'manage_churchcore' => true,
+                )
+            );
+        }
+
+        if ( ! get_role( 'churchcore_volunteer' ) ) {
+            add_role(
+                'churchcore_volunteer',
+                __( 'Church Volunteer', 'churchcore' ),
+                array(
+                    'read'              => true,
+                    'edit_posts'        => false,
+                    'churchcore_portal' => true,
+                )
+            );
+        }
+
+        $admin_role = get_role( 'administrator' );
+        if ( $admin_role && ! $admin_role->has_cap( 'manage_churchcore' ) ) {
+            $admin_role->add_cap( 'manage_churchcore' );
+        }
+    }
+
+    /**
+     * Registers custom post statuses for pastoral care.
+     */
+    public function register_statuses() {
+        register_post_status(
+            'pastoral-care',
+            array(
+                'label'                     => _x( 'Pastoral Care', 'post', 'churchcore' ),
+                'public'                    => true,
+                'show_in_admin_all_list'    => true,
+                'show_in_admin_status_list' => true,
+            )
+        );
+
+        register_post_status(
+            'follow-up',
+            array(
+                'label'                     => _x( 'Follow Up Needed', 'post', 'churchcore' ),
+                'public'                    => false,
+                'show_in_admin_all_list'    => true,
+                'show_in_admin_status_list' => true,
+            )
+        );
+    }
+
+    /**
+     * Registers REST API routes for the portal.
+     */
+    public function register_rest_routes() {
+        register_rest_route(
+            'churchcore/v1',
+            '/summary',
+            array(
+                'methods'             => 'GET',
+                'permission_callback' => array( $this, 'can_access_portal' ),
+                'callback'            => array( $this, 'get_summary' ),
+            )
+        );
+    }
+
+    /**
+     * REST capability check.
+     *
+     * @return bool
+     */
+    public function can_access_portal() {
+        return current_user_can( 'manage_churchcore' ) || current_user_can( 'churchcore_portal' );
+    }
+
+    /**
+     * Builds REST response summarizing key data.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function get_summary( $request ) {
+        $families = get_posts(
+            array(
+                'post_type'      => 'cc_family',
+                'posts_per_page' => 5,
+                'post_status'    => 'any',
+            )
+        );
+
+        $members = get_posts(
+            array(
+                'post_type'      => 'cc_person',
+                'posts_per_page' => 5,
+                'post_status'    => 'any',
+            )
+        );
+
+        $data = array(
+            'families' => array_map( array( $this, 'format_post_for_rest' ), $families ),
+            'people'   => array_map( array( $this, 'format_post_for_rest' ), $members ),
+        );
+
+        return rest_ensure_response( $data );
+    }
+
+    /**
+     * Formats posts for REST output.
+     *
+     * @param WP_Post $post Post object.
+     * @return array
+     */
+    protected function format_post_for_rest( $post ) {
+        return array(
+            'id'      => $post->ID,
+            'title'   => get_the_title( $post ),
+            'status'  => $post->post_status,
+            'link'    => get_edit_post_link( $post->ID, '' ),
+        );
+    }
+}

--- a/includes/class-churchcore-shortcodes.php
+++ b/includes/class-churchcore-shortcodes.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Front-end shortcodes and portal UI.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Registers shortcodes for self-serve portal.
+ */
+class ChurchCore_Shortcodes {
+    /**
+     * Registers hooks.
+     */
+    public function register() {
+        add_shortcode( 'churchcore_portal', array( $this, 'render_portal' ) );
+    }
+
+    /**
+     * Outputs the portal interface.
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string
+     */
+    public function render_portal( $atts ) {
+        if ( ! is_user_logged_in() ) {
+            return wp_kses_post( __( 'You must be logged in to view the ChurchCore portal.', 'churchcore' ) );
+        }
+
+        ob_start();
+        include CHURCHCORE_PLUGIN_DIR . 'includes/frontend/portal.php';
+        return ob_get_clean();
+    }
+}

--- a/includes/frontend/portal.php
+++ b/includes/frontend/portal.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Front-end portal renderer.
+ *
+ * @package ChurchCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$current_user = wp_get_current_user();
+$family_posts = get_posts(
+    array(
+        'post_type'      => 'cc_family',
+        'posts_per_page' => -1,
+        'author'         => $current_user->ID,
+        'post_status'    => array( 'publish', 'draft', 'pending', 'follow-up' ),
+    )
+);
+
+$person_posts = get_posts(
+    array(
+        'post_type'      => 'cc_person',
+        'posts_per_page' => -1,
+        'post_status'    => array( 'publish', 'draft', 'pending', 'follow-up' ),
+        'meta_query'     => array(
+            array(
+                'key'   => '_churchcore_email',
+                'value' => $current_user->user_email,
+            ),
+        ),
+    )
+);
+?>
+<div class="churchcore-portal">
+    <h2><?php esc_html_e( 'Welcome to ChurchCore', 'churchcore' ); ?></h2>
+    <p><?php echo esc_html( sprintf( __( 'Hi %s! Here is the latest from your church profile.', 'churchcore' ), $current_user->display_name ) ); ?></p>
+    <section class="churchcore-portal-section">
+        <h3><?php esc_html_e( 'Your Family Records', 'churchcore' ); ?></h3>
+        <?php if ( $family_posts ) : ?>
+            <ul>
+                <?php foreach ( $family_posts as $family ) :
+                    $status_obj   = get_post_status_object( $family->post_status );
+                    $status_label = $status_obj ? $status_obj->label : $family->post_status;
+                    ?>
+                    <li>
+                        <strong><?php echo esc_html( get_the_title( $family ) ); ?></strong><br />
+                        <span class="status"><?php echo esc_html( $status_label ); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else : ?>
+            <p><?php esc_html_e( 'No family records assigned yet.', 'churchcore' ); ?></p>
+        <?php endif; ?>
+    </section>
+    <section class="churchcore-portal-section">
+        <h3><?php esc_html_e( 'Your Involvement', 'churchcore' ); ?></h3>
+        <?php if ( $person_posts ) : ?>
+            <ul>
+                <?php foreach ( $person_posts as $person ) :
+                    $roles = wp_get_post_terms( $person->ID, 'cc_role', array( 'fields' => 'names' ) );
+                    ?>
+                    <li>
+                        <strong><?php echo esc_html( get_the_title( $person ) ); ?></strong><br />
+                        <span><?php echo esc_html( $roles ? implode( ', ', $roles ) : __( 'No roles assigned', 'churchcore' ) ); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else : ?>
+            <p><?php esc_html_e( 'No volunteer or staff assignments found.', 'churchcore' ); ?></p>
+        <?php endif; ?>
+    </section>
+    <section class="churchcore-portal-section">
+        <h3><?php esc_html_e( 'Need to update something?', 'churchcore' ); ?></h3>
+        <p><?php esc_html_e( 'Contact your church office or submit a Fluent Form connected to ChurchCore to request updates.', 'churchcore' ); ?></p>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- add the ChurchCore CMS bootstrap with database tables, roles, statuses, and a REST summary endpoint
- implement admin menus and screens for families, people, notes, and integrations along with shared styling
- provide a front-end portal shortcode for logged-in congregants to review their records

## Testing
- php -l churchcore.php
- php -l includes/class-churchcore-plugin.php
- php -l includes/class-churchcore-custom-post-types.php
- php -l includes/class-churchcore-admin-menu.php
- php -l includes/class-churchcore-integrations.php
- php -l includes/class-churchcore-shortcodes.php
- for file in includes/admin/views/*.php includes/frontend/portal.php; do php -l $file; done

------
https://chatgpt.com/codex/tasks/task_e_68e5d6b7235c8322858569fae39eab49